### PR TITLE
Fix unreachable code in resolve_credentials

### DIFF
--- a/plumPy.py
+++ b/plumPy.py
@@ -296,11 +296,6 @@ def resolve_credentials(device_name):
         return identity, password
     return WPA_IDENTITY, WPA_PASSWORD
 
-    if facility and facility in FACILITY_MAP:
-        return FACILITY_MAP[facility], WPA_PASSWORD
-    return WPA_IDENTITY, WPA_PASSWORD
-
-
 def configure_device(ip):
     session = requests.Session()
     session.verify = False


### PR DESCRIPTION
## Summary
- remove leftover logic after the early return in `resolve_credentials`

## Testing
- `python -m py_compile plumPy.py secrets_tool.py`

------
https://chatgpt.com/codex/tasks/task_e_684061b65620832d86b0ec49aca3b88f